### PR TITLE
non DOM dependant typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,28 @@
-/// <reference lib="dom" />
+// `AbortSignal`,`AbortController` are defined here to prevent a dependency on the `dom` library which disagrees with node runtime.
+// The definiction for `AbortSignal` is taken from @types/node-fetch (https://github.com/DefinitelyTyped/DefinitelyTyped) for 
+// maximal compatabilty with node-fetch.
+// Original node-fetch definitions are under MIT License.
 
-export default AbortController
+export interface AbortSignal {
+    aborted: boolean;
+
+    addEventListener: (type: "abort", listener: ((this: AbortSignal, event: any) => any), options?: boolean | {
+        capture?: boolean,
+        once?: boolean,
+        passive?: boolean
+    }) => void;
+
+    removeEventListener: (type: "abort", listener: ((this: AbortSignal, event: any) => any), options?: boolean | {
+        capture?: boolean
+    }) => void;
+
+    dispatchEvent: (event: any) => boolean;
+
+    onabort?: null | ((this: AbortSignal, event: any) => void);
+}
+
+export default class AbortController {
+	signal:AbortSignal;
+	abort() :void;
+}
+


### PR DESCRIPTION
having  <reference lib="dom" />  in recent NodeJS environment clashes with timer types and probably other types. This is much cleaner approach for a node-* package 