### PR TITLE
feat: make AbortSignal class available outside

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 // `AbortSignal`,`AbortController` are defined here to prevent a dependency on the `dom` library which disagrees with node runtime.
-// The definiction for `AbortSignal` is taken from @types/node-fetch (https://github.com/DefinitelyTyped/DefinitelyTyped) for 
-// maximal compatabilty with node-fetch.
+// The definition for `AbortSignal` is taken from @types/node-fetch (https://github.com/DefinitelyTyped/DefinitelyTyped) for
+// maximal compatibility with node-fetch.
 // Original node-fetch definitions are under MIT License.
 
-export interface AbortSignal {
+export class AbortSignal {
     aborted: boolean;
 
     addEventListener: (type: "abort", listener: ((this: AbortSignal, event: any) => any), options?: boolean | {

--- a/index.js
+++ b/index.js
@@ -21,12 +21,12 @@ class AbortSignal {
   dispatchEvent(type) {
     const event = { type, target: this }
     const handlerName = `on${type}`;
-    
+
     if (typeof this[handlerName] === 'function')
       this[handlerName](event)
 
     this.eventEmitter.emit(type, event)
-  }  
+  }
 }
 class AbortController {
   constructor() {
@@ -35,7 +35,7 @@ class AbortController {
   abort() {
     if (this.signal.aborted)
       return
-    
+
     this.signal.aborted = true
     this.signal.dispatchEvent('abort')
   }
@@ -49,3 +49,4 @@ class AbortController {
 
 module.exports = AbortController
 module.exports.default = AbortController
+module.exports.AbortSignal = AbortSignal;


### PR DESCRIPTION
Sometimes we need to check if object is an AbortSignal or instantiate it outside the controller for variety of reasons.