### PR TITLE
named export of AbortController

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,8 +21,9 @@ export class AbortSignal {
     onabort: null | ((this: AbortSignal, event: any) => void);
 }
 
-export default class AbortController {
+export class AbortController {
 	signal:AbortSignal;
 	abort() :void;
 }
 
+export default AbortController;

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ class AbortController {
   }
 }
 
-module.exports = AbortController
-module.exports.default = AbortController
+module.exports = AbortController;
+module.exports.default = AbortController;
+module.exports.AbortController = AbortController;
 module.exports.AbortSignal = AbortSignal;


### PR DESCRIPTION
Since we have several exported things out of the module, it is better in several ways to named export the `AbortController`:
1. IDE suggestions
2. Different styleguides suggestions
3. No mess when importing both `AbortController` and `AbortSignal` at once