### PR TITLE
Make import isomorphic

### DIFF
--- a/__tests__/abort-controller.browser.js
+++ b/__tests__/abort-controller.browser.js
@@ -1,0 +1,19 @@
+describe("AbortController in browser", function () {
+  // Mock AbortController
+  const mockedGlobalAbortController = jest.fn();
+
+  beforeAll(() => {
+    // Attach mocked AbortController to global
+    self.AbortController = mockedGlobalAbortController;
+  });
+
+  it("should call global abort controller", function () {
+    // Require module after global setup
+    const { AbortController } = require("../browser.js");
+
+    const controller = new AbortController();
+
+    expect(controller).toBeTruthy();
+    expect(mockedGlobalAbortController).toBeCalled();
+  });
+});

--- a/browser.js
+++ b/browser.js
@@ -20,4 +20,5 @@ if (!_global.AbortController) {
 }
 
 module.exports = _global.AbortController
+module.exports.AbortController = _global.AbortController
 module.exports.default = _global.AbortController

--- a/index.js
+++ b/index.js
@@ -46,3 +46,4 @@ class AbortController {
 }
 
 module.exports = { AbortController, AbortSignal };
+module.exports.default = AbortController;

--- a/index.js
+++ b/index.js
@@ -46,4 +46,3 @@ class AbortController {
 }
 
 module.exports = { AbortController, AbortSignal };
-module.exports.default = AbortController;


### PR DESCRIPTION
Making the import isomorphic in both browser and nodejs

Problem:
In node environment we will consume this package as:
```import { AbortController } from 'node-abort-controller```

However, we reexport browser AbortController in browser.js but the export doesn't match the node syntax. Therefore
```import { AbortController } from 'node-abort-controller```
will throw in browser.

Solution:
updating the export in both browser.js and index.js so we can do:
```import { AbortController } from 'node-abort-controller'``` or ```import AbortController from 'node-abort-controller'```