### PR TITLE
Add Support reason and throwIfAborted

### DIFF
--- a/__tests__/abort-controller.js
+++ b/__tests__/abort-controller.js
@@ -8,6 +8,7 @@ describe("AbortController", function () {
 
     expect(signal.onabort).toBeNull();
     expect(signal.aborted).toBe(false);
+    expect(signal.reason).toBeUndefined();
 
     signal.onabort = jest.fn();
     signal.addEventListener("abort", handler);
@@ -15,6 +16,7 @@ describe("AbortController", function () {
     controller.abort();
 
     expect(signal.aborted).toBe(true);
+    expect(signal.reason).toEqual(new Error("AbortError"));
     expect(handler).toBeCalledTimes(1);
     expect(handler).toBeCalledWith({ type: "abort", target: signal });
     expect(signal.onabort).toBeCalledTimes(1);
@@ -24,7 +26,21 @@ describe("AbortController", function () {
     controller.abort();
 
     expect(signal.aborted).toBe(true);
+    expect(signal.reason).toEqual(new Error("AbortError"));
     expect(handler).not.toBeCalled();
     expect(signal.onabort).not.toBeCalled();
+  });
+
+  it("should use custom abort reason", () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    expect(signal.aborted).toBe(false);
+    expect(signal.reason).toBeUndefined();
+
+    const customReason = new Error("Custom Reason");
+    controller.abort(customReason);
+
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toBe(customReason);
   });
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@
 
 export class AbortSignal {
   aborted: boolean;
+  reason?: any;
 
   addEventListener: (
     type: "abort",
@@ -31,9 +32,16 @@ export class AbortSignal {
   dispatchEvent: (event: any) => boolean;
 
   onabort: null | ((this: AbortSignal, event: any) => void);
+
+  throwIfAborted(): void;
+
+  static abort(reason?: any): AbortSignal;
+
+  static timeout(time: number): AbortSignal;
 }
 
 export class AbortController {
   signal: AbortSignal;
-  abort(): void;
+
+  abort(reason?: any): void;
 }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ class AbortSignal {
     this.eventEmitter = new EventEmitter();
     this.onabort = null;
     this.aborted = false;
+    this.reason = undefined;
   }
   toString() {
     return "[object AbortSignal]";
@@ -26,15 +27,34 @@ class AbortSignal {
 
     this.eventEmitter.emit(type, event);
   }
+  throwIfAborted() {
+    if (this.aborted) {
+      throw this.reason;
+    }
+  }
+  static abort(reason) {
+    const controller = new AbortController();
+    controller.abort();
+    return controller.signal;
+  }
+  static timeout(time) {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(new Error("TimeoutError")), time);
+    return controller.signal;
+  }
 }
 class AbortController {
   constructor() {
     this.signal = new AbortSignal();
   }
-  abort() {
+  abort(reason) {
     if (this.signal.aborted) return;
 
     this.signal.aborted = true;
+
+    if (reason) this.signal.reason = reason;
+    else this.signal.reason = new Error("AbortError");
+
     this.signal.dispatchEvent("abort");
   }
   toString() {


### PR DESCRIPTION
This is my initial implementation of `reason` and `throwIfAborted`.

It also adds the `abort` and `timeout` static methods on `AbortSignal`.

fixes #31