### PR TITLE
Added engines check

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "testEnvironment": "jsdom"
   },
   "engines": {
-    "node": "14.x"
+    "node": "<14.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   },
   "jest": {
     "testEnvironment": "jsdom"
+  },
+  "engines": {
+    "node": "<15.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "testEnvironment": "jsdom"
   },
   "engines": {
-    "node": "<15.4"
+    "node": "14.x"
   }
 }


### PR DESCRIPTION
As per the [Node Docs](https://nodejs.org/api/globals.html#class-abortcontroller), the AbortController is available natively without experimental flags since Node 15.4, as such we should implicitly prevent developers from using this library instead of the native one.