### PR TITLE
docs: fixed Node.js version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AbortController Polyfill for Node.JS based on EventEmitter for Node v14 and below.
 
-Are you using Node 16 or above? You don't need this! [Node has `AbortController` and `AbortSignal` as builtin globals](https://nodejs.org/dist/latest-v16.x/docs/api/globals.html#class-abortcontroller)
+Are you using Node 15.4 or above? You don't need this! [Node has `AbortController` and `AbortSignal` as builtin globals](https://nodejs.org/dist/latest-v16.x/docs/api/globals.html#class-abortcontroller)
 
 [![Build Status](https://dev.azure.com/stfaul/node-abort-controller/_apis/build/status/southpolesteve.node-abort-controller?branchName=master)](https://dev.azure.com/stfaul/node-abort-controller/_build/latest?definitionId=3&branchName=master)
 


### PR DESCRIPTION
As proposed in #34 , 15.4 is the version in which the AbortController has been introduced without flags, so I think it should be represented in the same way here.