### PR TITLE
Revert "set engines" change

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,5 @@
   },
   "jest": {
     "testEnvironment": "jsdom"
-  },
-  "engines": {
-    "node": "<14.7.0"
   }
 }


### PR DESCRIPTION
Issue: #39 

Hey @southpolesteve @Cadienvan @Ethan-Arrowood, the changes done in #38 ended up having some side effects which caused many projects to break on their install step. This change probably should be done as part of a major release instead.

This PR reverts that change so we can avoid the big impact it might have for projects that have `node-abort-controller` as a transitive dependency.