### PR TITLE
chore: exclude test files and CI config from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+__tests__
+.github


### PR DESCRIPTION
The `__tests__/` directory and `.github/` workflows are currently included in the published npm package but are not needed by consumers.

This PR adds a `.npmignore` file to exclude them from the tarball, reducing the package size.

**Before:**
```
npm notice 1.5kB __tests__/abort-controller.js
npm notice 2.4kB __tests__/abort-signal.js
npm notice 565B  __tests__/browser.js
npm notice 886B  __tests__/node-fetch.js
npm notice 892B  __tests__/whatwg-fetch.js
npm notice 357B  .github/workflows/test.yml
```

**After:**
Test and CI files no longer shipped.